### PR TITLE
Implement basic version operations

### DIFF
--- a/src/versions.fs
+++ b/src/versions.fs
@@ -1,0 +1,77 @@
+module FsVersion.Utils
+
+open System
+
+let private _Coerce n = Math.Max(0, n)
+let private _Incr n = n + 1
+let private _Decr n = n - 1
+
+type VersionType =
+  | Major
+  | Minor
+  | Patch
+
+// Borrowed from http://stackoverflow.com/a/2226375
+let (|InvariantEqual|_|) (str: string) arg =
+  if String.Compare(str, arg, StringComparison.OrdinalIgnoreCase) = 0 then
+    Some()
+  else
+    None
+
+let versionTypeFromString versionTypeStr =
+  match versionTypeStr with
+  | InvariantEqual "major" -> Major
+  | InvariantEqual "minor" -> Minor
+  | _ -> Patch
+
+let CoerceVersionToFourVersion (version: Version) =
+  new Version(
+    _Coerce version.Major,
+    _Coerce version.Minor,
+    _Coerce version.Build,
+    _Coerce version.Revision)
+
+let CoerceStringToFourVersion version =
+  CoerceVersionToFourVersion (Version.Parse(version))
+
+let CoerceVersionToSemVer (version: Version) =
+  new Version(
+    _Coerce version.Major,
+    _Coerce version.Minor,
+    _Coerce version.Build)
+
+let CoerceStringToSemVer version =
+  CoerceVersionToSemVer (Version.Parse(version))
+
+let BuildSemVer major minor patch =
+  new System.Version(
+    _Coerce major,
+    _Coerce minor,
+    _Coerce patch)
+
+let ApplyMajor fn versionString =
+  let current = Version.Parse(versionString)
+  let newMajor = fn (_Coerce current.Major)
+
+  (BuildSemVer newMajor 0 0).ToString()
+
+let ApplyMinor fn versionString =
+  let current = Version.Parse(versionString)
+  let newMinor = fn (_Coerce current.Minor)
+
+  (BuildSemVer current.Major newMinor 0).ToString()
+
+let ApplyPatch fn versionString =
+  let current = Version.Parse(versionString)
+  let newPatch = fn (_Coerce current.Build)
+
+  (BuildSemVer current.Major current.Minor newPatch).ToString()
+
+
+let IncrMajor = ApplyMajor _Incr
+let IncrMinor = ApplyMinor _Incr
+let IncrPatch = ApplyPatch _Incr
+
+let DecrMajor = ApplyMajor _Decr
+let DecrMinor = ApplyMinor _Decr
+let DecrPatch = ApplyPatch _Decr


### PR DESCRIPTION
Need to write tests next.

In the meantime, verification these are working can be done by doing the following:
1. Start F# Repl in repo root.
2. `#load @"./src/versions.fs";;`
3. A namespace like `FSI_0002.FsVersion` should be printed out.
   - Run `open FSI_0002.FsVersion.Utils;;`

You should now be able to invoke any of the public functions in the FsVersion.Utils modules.

That will look something like this:

```
> IncrMajor "1.2.3";;
val it : string = "2.0.0"
```
