### PR TITLE
Increment minor -> 0.3.0

### DIFF
--- a/AssemblyInfo.fs
+++ b/AssemblyInfo.fs
@@ -24,9 +24,9 @@ open System.Runtime.InteropServices
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[<assembly: AssemblyVersion("0.2.1.0")>]
-[<assembly: AssemblyFileVersion("0.2.1.0")>]
-[<assembly: AssemblyInformationalVersion("0.2.1")>]
+[<assembly: AssemblyVersion("0.3.0.0")>]
+[<assembly: AssemblyFileVersion("0.3.0.0")>]
+[<assembly: AssemblyInformationalVersion("0.3.0")>]
 
 do
     ()


### PR DESCRIPTION
This is minor because members of a public API have been deprecated.
See [here](http://semver.org/#spec-item-7) for more info.
